### PR TITLE
[codex] Adjust blog prose heading scale

### DIFF
--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -45,6 +45,18 @@ const { title, description, pubDate, updatedDate, heroImage } = Astro.props;
 			.title h1 {
 				margin: 0 0 0.5em 0;
 			}
+			.prose h1 {
+				font-size: 2.441em;
+			}
+			.prose h2 {
+				font-size: 1.953em;
+			}
+			.prose h3 {
+				font-size: 1.563em;
+			}
+			.prose h4 {
+				font-size: 1.25em;
+			}
 			.date {
 				margin-bottom: 0.5em;
 				color: rgb(var(--gray));


### PR DESCRIPTION
## Summary

- Reduce Markdown body heading sizes in `BlogPost.astro` by one scale step for `h1` through `h4`.
- Keep the article title styling unchanged by scoping the change to `.prose`.

## Validation

- `npm run build`