### PR TITLE
feat: use blog hero image for OGP metadata

### DIFF
--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -13,7 +13,7 @@ const { title, description, pubDate, updatedDate, heroImage } = Astro.props;
 
 <html lang="en">
 	<head>
-		<BaseHead title={title} description={description} />
+		<BaseHead title={title} description={description} image={heroImage} />
 		<style>
 			main {
 				width: calc(100% - 2em);

--- a/test/ogp-hero-image.test.mjs
+++ b/test/ogp-hero-image.test.mjs
@@ -1,0 +1,24 @@
+import { readFile } from 'node:fs/promises';
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+test('blog post OGP images use the post heroImage asset', async () => {
+	const postPath = 'dist/blog/2026-05-07-agentic-restaurant-ordering-and-payment/index.html';
+	const html = await readFile(postPath, 'utf8');
+
+	const ogImage = html.match(/<meta property="og:image" content="([^"]+)"/u)?.[1];
+	const twitterImage = html.match(/<meta property="twitter:image" content="([^"]+)"/u)?.[1];
+
+	assert.ok(ogImage, 'og:image meta tag should exist');
+	assert.ok(twitterImage, 'twitter:image meta tag should exist');
+	assert.match(
+		ogImage,
+		/agentic-restaurant-ordering-hero\.[^/]+\.(?:png|webp)$/u,
+		'blog post og:image should use the post heroImage asset',
+	);
+	assert.match(
+		twitterImage,
+		/agentic-restaurant-ordering-hero\.[^/]+\.(?:png|webp)$/u,
+		'blog post twitter:image should use the post heroImage asset',
+	);
+});


### PR DESCRIPTION
## Summary
- Pass each blog post's `heroImage` into `BaseHead` so `og:image` and `twitter:image` use the post-specific hero asset
- Add a Node test that builds against the published agentic restaurant ordering post and asserts its OGP image metadata points to the hero image

## Verification
- [x] Watched the new OGP test fail before implementation: fallback `kasane.png` was used
- [x] `npm run build`
- [x] `npm test`

## Note
- `npm run lint:text` currently reports the intentionally half-width `ｽﾀｯｸﾁｬﾝ` wording in the existing article via `ja-technical-writing/no-hankaku-kana`; this PR does not change article copy.
