### PR TITLE
style: reduce blog type scale

### DIFF
--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -44,18 +44,20 @@ const { title, description, pubDate, updatedDate, heroImage } = Astro.props;
 			}
 			.title h1 {
 				margin: 0 0 0.5em 0;
+				font-size: clamp(1.875rem, 6vw, 2.25rem);
+				line-height: 1.2;
 			}
 			.prose h1 {
-				font-size: 2.441em;
+				font-size: 1.75rem;
 			}
 			.prose h2 {
-				font-size: 1.953em;
+				font-size: 1.5rem;
 			}
 			.prose h3 {
-				font-size: 1.563em;
+				font-size: 1.25rem;
 			}
 			.prose h4 {
-				font-size: 1.25em;
+				font-size: 1.0625rem;
 			}
 			.date {
 				margin-bottom: 0.5em;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -23,7 +23,7 @@ body {
 	word-wrap: break-word;
 	overflow-wrap: break-word;
 	color: rgb(var(--gray-dark));
-	font-size: 20px;
+	font-size: 17px;
 	line-height: 1.7;
 }
 main {
@@ -40,22 +40,22 @@ h5,
 h6 {
 	margin: 0 0 0.5rem 0;
 	color: rgb(var(--black));
-	line-height: 1.2;
+	line-height: 1.25;
 }
 h1 {
-	font-size: 3.052em;
+	font-size: 2.25rem;
 }
 h2 {
-	font-size: 2.441em;
+	font-size: 1.75rem;
 }
 h3 {
-	font-size: 1.953em;
+	font-size: 1.375rem;
 }
 h4 {
-	font-size: 1.563em;
+	font-size: 1.125rem;
 }
 h5 {
-	font-size: 1.25em;
+	font-size: 1rem;
 }
 strong,
 b {
@@ -112,7 +112,7 @@ hr {
 }
 @media (max-width: 720px) {
 	body {
-		font-size: 18px;
+		font-size: 16px;
 	}
 	main {
 		padding: 1em;


### PR DESCRIPTION
## Summary
- reduce the global body font size from 20px to 17px
- reduce the mobile body font size from 18px to 16px
- make article titles and in-article headings more restrained with fixed rem/clamp scales

## Verification
- npm ci
- npm run build
- local browser visual check on the latest article page